### PR TITLE
Tasks directory is not updated after editing configuration

### DIFF
--- a/src/name/admitriev/jhelper/components/ChromeParser.java
+++ b/src/name/admitriev/jhelper/components/ChromeParser.java
@@ -57,11 +57,6 @@ public class ChromeParser implements ProjectComponent {
 	@Override
 	public void projectOpened() {
 		try {
-			Configurator configurator = project.getComponent(Configurator.class);
-			Configurator.State configuration = configurator.getState();
-
-			String path = configuration.getTasksDirectory();
-
 			server = new SimpleHttpServer(
 					PORT,
 					request -> {
@@ -85,6 +80,10 @@ public class ChromeParser implements ProjectComponent {
 									NotificationType.WARNING
 							);
 						}
+
+						Configurator configurator = project.getComponent(Configurator.class);
+						Configurator.State configuration = configurator.getState();
+						String path = configuration.getTasksDirectory();
 						for (Task rawTask : tasks) {
 							TaskData task = new TaskData(
 									rawTask.name,


### PR DESCRIPTION
I used `Competitive Companion` after editing tasks directory configuration, but tasks directory wasn't updated.  Tasks directory was set by `projectOpened()`, so I had to reopen CLion after editing configuration.

I fixed that tasks directory is set when receiving a request.