### PR TITLE
Migrate to 2020.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '0.4.21'
+    id 'org.jetbrains.intellij' version '0.6.5'
 }
 
 group 'name.admitriev.jhelper'
@@ -27,7 +27,8 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version '2020.1.1'
+    version '2020.3'
     updateSinceUntilBuild false
     type 'CL'
+    setPlugins('com.intellij.clion', 'com.intellij.cidr.lang')
 }

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -10,7 +10,7 @@
         In 0.18 Copy Output Action now (re)generates the output files.
     </change-notes>
 
-    <idea-version since-build="201.6487.17"/>
+    <idea-version since-build="203.5981"/>
 
     <depends>com.intellij.modules.cidr.lang</depends>
     <depends>com.intellij.clion</depends>

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -13,7 +13,7 @@
     <idea-version since-build="201.6487.17"/>
 
     <depends>com.intellij.modules.cidr.lang</depends>
-    <depends>com.intellij.modules.clion</depends>
+    <depends>com.intellij.clion</depends>
 
     <extensions defaultExtensionNs="com.intellij">
         <configurationType implementation="name.admitriev.jhelper.configuration.TaskConfigurationType"/>


### PR DESCRIPTION
Migrate plugin to CLion 2020.3
https://blog.jetbrains.com/clion/2020/12/migration-guide-for-plugins-2020-3/