### PR TITLE
Fix NPE in Notificator

### DIFF
--- a/src/name/admitriev/jhelper/actions/ConfigureAction.java
+++ b/src/name/admitriev/jhelper/actions/ConfigureAction.java
@@ -1,12 +1,10 @@
 package name.admitriev.jhelper.actions;
 
-import com.intellij.notification.NotificationType;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
 import name.admitriev.jhelper.components.Configurator;
 import name.admitriev.jhelper.exceptions.NotificationException;
 import name.admitriev.jhelper.ui.ConfigurationDialog;
-import name.admitriev.jhelper.ui.Notificator;
 
 public class ConfigureAction extends BaseAction {
 	@Override
@@ -16,7 +14,6 @@ public class ConfigureAction extends BaseAction {
 			throw new NotificationException("No project found", "Are you in any project?");
 		}
 
-		Notificator.showNotification("test", NotificationType.WARNING);
 		Configurator configurator = project.getService(Configurator.class);
 		Configurator.State configuration = configurator.getState();
 

--- a/src/name/admitriev/jhelper/ui/Notificator.java
+++ b/src/name/admitriev/jhelper/ui/Notificator.java
@@ -5,7 +5,7 @@ import com.intellij.notification.NotificationGroupManager;
 import com.intellij.notification.NotificationType;
 
 public class Notificator {
-	private static final NotificationGroup GROUP = NotificationGroupManager.getInstance().getNotificationGroup("name.admitriev.jhelper.Notificator");
+	private static final NotificationGroup GROUP = NotificationGroupManager.getInstance().getNotificationGroup("JHelper");
 
 	private Notificator() {
 	}


### PR DESCRIPTION
Set up correct group id for Notificator to avoid NPE on every opening of configurations and remove test notification.